### PR TITLE
Change filter qps channel_id, show_id to channel, show

### DIFF
--- a/app/models/channel.js
+++ b/app/models/channel.js
@@ -35,7 +35,7 @@ export default DS.Model.extend({
 			var promise = this.store.find('schedule-item', {
 				start: _start,
 				end: _end,
-				channel_id: this.get('id')
+				channel: this.get('id')
 			}).
 			then(function(items) {
 				return items.filter(function(run) {

--- a/app/models/show.js
+++ b/app/models/show.js
@@ -44,7 +44,7 @@ export default DS.Model.extend({
     	var _start = moment(today).startOf('day').format();
 
     	return this.store.find('schedule-item', {
-	    	show_id: this.id,
+	    	show: this.id,
     		start: _start,
     		page_size: 5
 	    });

--- a/app/routes/schedule.js
+++ b/app/routes/schedule.js
@@ -13,7 +13,7 @@ export default Ember.Route.extend({
 		var _end = moment(params.currentDay).add(1, 'days').format();
 
     	return this.store.find('schedule-item', {
-	    	channel_id: appParams.channel,
+	    	channel: appParams.channel,
     		start: _start,
     		end: _end
 	    }).

--- a/app/routes/show.js
+++ b/app/routes/show.js
@@ -6,7 +6,7 @@ export default Ember.Route.extend({
 		return Ember.RSVP.hash({
 			show: this.store.find('show', params.id),
 			runs: this.store.find('schedule-item', {
-	    	show_id: params.id,
+	    	show: params.id,
     		start: start.toISOString(),
     		page_size: 5
 	    })


### PR DESCRIPTION
This was a last minute change in some of the new Cablecast 6.0 API to
make the filter query params consistent without we embed relationships
in JSON payloads.

Unfortunetly this did not get caught before release, so now the schedule
/ upcoming runs aren't getting the correct filters applied