### PR TITLE
Fix issue calculating schedule time ranges

### DIFF
--- a/app/adapters/show.js
+++ b/app/adapters/show.js
@@ -1,0 +1,16 @@
+import ApplicationAdapter from 'public/adapters/application';
+
+export default ApplicationAdapter.extend({
+  coalesceFindRequests: true,
+	buildURL: function(modelName, id, snapshot, requestType, query) {
+		var url = this._super(modelName, id, snapshot, requestType, query);
+    switch (requestType) {
+      case 'findMany':
+        url += '?include=reel,webfile';
+        break;
+      default:
+        break;
+    }
+		return url;
+	}
+});

--- a/app/models/channel.js
+++ b/app/models/channel.js
@@ -35,7 +35,8 @@ export default DS.Model.extend({
 			var promise = this.store.find('schedule-item', {
 				start: _start,
 				end: _end,
-				channel: this.get('id')
+				channel: this.get('id'),
+				include: 'show,reel'
 			}).
 			then(function(items) {
 				return items.filter(function(run) {

--- a/app/routes/schedule.js
+++ b/app/routes/schedule.js
@@ -10,12 +10,13 @@ export default Ember.Route.extend({
 	model: function(params){
 		var appParams = this.paramsFor('application');
   		var _start = moment(params.currentDay).startOf('day').format();
-		var _end = moment(params.currentDay).add(1, 'days').format();
+			var _end = moment(params.currentDay).add(1, 'days').format();
 
     	return this.store.find('schedule-item', {
 	    	channel: appParams.channel,
     		start: _start,
-    		end: _end
+    		end: _end,
+				include: 'show,reel'
 	    }).
 			then(function(runs) {
 				return runs.filter(function(run) {


### PR DESCRIPTION
We need to sideload the shows and reels in order to make the channel models `schedule` property accurate. If those models aren't loaded with the schedule item, the `end` calculattion errors, causing all events to be left in the collection. Ideallly we would refactor the way this works as it doesn't take advantage of data binding.