### PR TITLE
Use embedCode and not video tag

### DIFF
--- a/app/templates/show.hbs
+++ b/app/templates/show.hbs
@@ -9,11 +9,7 @@
     	<div class="embed-responsive embed-responsive-16by9">
       	{{#if show.vods.firstObject.isReady}}
 			<div class="embed-responsive embed-responsive-16by9">
-				<video
-					src={{show.vods.firstObject.url}}
-					poster={{show.thumbnail}}
-					class="embed-responsive-item" controls>
-				</video>
+        {{{show.vods.firstObject.embedCode}}}
 			</div>
 		{{else}}
 			{{show-thumbnail show=show quality='Large' class="img-responsive"}}


### PR DESCRIPTION
This has the issue of no poster support since we don't support that in our player. I think this should be blocked from merging until we add poster support to the videojs player in Cablecast