### PR TITLE
bugzid: 10124 - Get full schedule from api

### DIFF
--- a/app/models/channel.js
+++ b/app/models/channel.js
@@ -36,7 +36,9 @@ export default DS.Model.extend({
 				start: _start,
 				end: _end,
 				channel: this.get('id'),
-				include: 'show,reel'
+				include: 'show,reel',
+        include_cg_exempt: false,
+        page_size: -1
 			}).
 			then(function(items) {
 				return items.filter(function(run) {

--- a/app/routes/schedule.js
+++ b/app/routes/schedule.js
@@ -16,7 +16,9 @@ export default Ember.Route.extend({
 	    	channel: appParams.channel,
     		start: _start,
     		end: _end,
-				include: 'show,reel'
+				include: 'show,reel',
+        page_size: -1,
+        include_cg_exempt: false
 	    }).
 			then(function(runs) {
 				return runs.filter(function(run) {


### PR DESCRIPTION
This takes advantage of the new filter on schedule items endpoint so even though we are getting unlimited results in the first page, we are only getting non-cg-exempt which there shouldn't be more than a few hundred in a day.