### PR TITLE
cc-99 generate a web.config to be installed in the parent folder

### DIFF
--- a/public/web.config
+++ b/public/web.config
@@ -1,19 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-  <system.webServer>
-    <handlers>
-    	<add name="iisnode" path="fastboot-server.iisnode" verb="*" modules="iisnode" />
-    </handlers>
-    <iisnode loggingEnabled="true" />
-    <rewrite>
-       <rules>
-         <rule name="hello">
-           <match url="/*" />
-           <conditions>
-             <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
-           </conditions>
-           <action type="Rewrite" url="fastboot-server.iisnode" />
-         </rule>
-       </rules>
-     </rewrite>
-  </system.webServer>
+    <system.webServer>
+        <rewrite>
+            <rules>
+                <clear />
+                <rule name="public site canonical url" stopProcessing="true">
+                    <match url="^(cablecastpublicsite)(.*)" />
+                    <conditions logicalGrouping="MatchAll" trackAllCaptures="false">
+                        <add input="{REQUEST_URI}" pattern="^CablecastPublicSite.*" ignoreCase="false" negate="true" />
+                    </conditions>
+                    <action type="Rewrite" url="CablecastPublicSite{R:2}" />
+                </rule>
+                <rule name="add trailing slash" enabled="true" stopProcessing="true">
+                    <match url="^(/CablecastPublicSite.*[^/])$" />
+                    <conditions logicalGrouping="MatchAll" trackAllCaptures="false">
+                        <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+                        <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+                    </conditions>
+                    <action type="Redirect" url="{R:1}/" />
+                </rule>
+            </rules>
+        </rewrite>
+    </system.webServer>
 </configuration>


### PR DESCRIPTION
redirects in iis ensure that /cablecastpublicsite is now always
accessed through a single url. Will make it easier for users, as well as
being better for SEO.

Add a trailing slash in the url if it's missing.