### PR TITLE
cc-97 set the browser's title dynamically

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Public</title>
+    
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/app/mixins/set-page-title.js
+++ b/app/mixins/set-page-title.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+  fastboot: Ember.inject.service(),
+  headData: Ember.inject.service(),
+
+  setTitle(title) {
+    if (this.get('fastboot.isFastBoot')) {
+      this.get('headData').set('title', title);
+    }
+    else {
+      document.title = title;
+    }
+  }
+});

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -33,7 +33,7 @@ export default Ember.Route.extend({
       card: 'summary',
       title: publicSite.get('siteName'),
       description: publicSite.get('aboutPageDescription'),
-      image: publicSite.get('logo.url'),
+      image: publicSite.get('logo.url')
     };
     headData.set('url', url);
     headData.set('socialMedia', data);

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import SetPageTitle from 'public/mixins/set-page-title'
 
 function filterShows(shows) {
 	return shows.filter(function(show) {
@@ -6,15 +7,14 @@ function filterShows(shows) {
 	}).slice(0, 16);
 }
 
-export default Ember.Route.extend({
+export default Ember.Route.extend(SetPageTitle, {
 	recentPrograms: null,
 	galleryName: 'Latest videos',
 	headData: Ember.inject.service(),
 
-	activate: function() {
+	afterModel: function() {
 		var channel = this.modelFor('application').channel;
-		let headData = this.get('headData');
-		headData.set('title', channel.get('name'));
+		this.setTitle(channel.get('name'));
 	},
 
 	model: function() {

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -9,6 +9,14 @@ function filterShows(shows) {
 export default Ember.Route.extend({
 	recentPrograms: null,
 	galleryName: 'Latest videos',
+	headData: Ember.inject.service(),
+
+	activate: function() {
+		var channel = this.modelFor('application').channel;
+		let headData = this.get('headData');
+		headData.set('title', channel.get('name'));
+	},
+
 	model: function() {
 		var self = this;
 		var channel = this.modelFor('application').channel;

--- a/app/routes/podcasts.js
+++ b/app/routes/podcasts.js
@@ -1,11 +1,9 @@
 import Ember from 'ember';
+import SetPageTitle from 'public/mixins/set-page-title';
 
-export default Ember.Route.extend({
-  headData: Ember.inject.service(),
-
+export default Ember.Route.extend(SetPageTitle, {
   afterModel() {
-    let headData = this.get('headData');
-    headData.set('title', 'Podcasts');
+    this.setTitle('Podcasts');
   },
 
   model: function() {

--- a/app/routes/podcasts.js
+++ b/app/routes/podcasts.js
@@ -1,6 +1,13 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  headData: Ember.inject.service(),
+
+  afterModel() {
+    let headData = this.get('headData');
+    headData.set('title', 'Podcasts');
+  },
+
   model: function() {
     return this.store.findAll('project').
       then(function(projects) {

--- a/app/routes/schedule.js
+++ b/app/routes/schedule.js
@@ -1,9 +1,8 @@
 /* globals moment */
 import Ember from 'ember';
+import SetPageTitle from 'public/mixins/set-page-title';
 
-export default Ember.Route.extend({
-	headData: Ember.inject.service(),
-
+export default Ember.Route.extend(SetPageTitle, {
 	queryParams: {
 		currentDay: {
 			refreshModel: true
@@ -11,8 +10,7 @@ export default Ember.Route.extend({
 	},
 
   afterModel() {
-    let headData = this.get('headData');
-    headData.set('title', 'Schedule');
+		this.setTitle('Schedule');
   },
 
 	model: function(params){

--- a/app/routes/schedule.js
+++ b/app/routes/schedule.js
@@ -2,11 +2,19 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+	headData: Ember.inject.service(),
+
 	queryParams: {
 		currentDay: {
 			refreshModel: true
 		}
 	},
+
+  afterModel() {
+    let headData = this.get('headData');
+    headData.set('title', 'Schedule');
+  },
+
 	model: function(params){
 		var appParams = this.paramsFor('application');
   		var _start = moment(params.currentDay).startOf('day').format();

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+	headData: Ember.inject.service(),
+
 	queryParams: {
 		query: {
 			refreshModel: true
@@ -9,6 +11,12 @@ export default Ember.Route.extend({
 			refreshModel: true
 		}
 	},
+
+	afterModel() {
+		let headData = this.get('headData');
+		headData.set('title', 'Search Results');
+	},
+
 	model: function(params) {
 		var channel = this.modelFor('application').channel;
 		return this.store.query('show', {

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -1,8 +1,7 @@
 import Ember from 'ember';
+import SetPageTitle from 'public/mixins/set-page-title';
 
-export default Ember.Route.extend({
-	headData: Ember.inject.service(),
-
+export default Ember.Route.extend(SetPageTitle, {
 	queryParams: {
 		query: {
 			refreshModel: true
@@ -13,8 +12,7 @@ export default Ember.Route.extend({
 	},
 
 	afterModel() {
-		let headData = this.get('headData');
-		headData.set('title', 'Search Results');
+		this.setTitle('Search Results');
 	},
 
 	model: function(params) {

--- a/app/routes/show.js
+++ b/app/routes/show.js
@@ -1,8 +1,7 @@
 import Ember from 'ember';
+import SetPageTitle from 'public/mixins/set-page-title';
 
-export default Ember.Route.extend({
-	headData: Ember.inject.service(),
-
+export default Ember.Route.extend(SetPageTitle, {
 	setHeadData(show) {
     let thumbnail = show.get('showThumbnails').findBy('quality', 'Large');
     if (!thumbnail) {
@@ -17,7 +16,7 @@ export default Ember.Route.extend({
 			image: (thumbnail ? thumbnail.get('url') : null)
 		};
 		headData.set('socialMedia', data);
-		headData.set('title', show.get('cgTitle'));
+		this.setTitle(show.get('cgTitle'));
 	},
 
 	model: function(params) {

--- a/app/routes/show.js
+++ b/app/routes/show.js
@@ -17,6 +17,7 @@ export default Ember.Route.extend({
 			image: (thumbnail ? thumbnail.get('url') : null)
 		};
 		headData.set('socialMedia', data);
+		headData.set('title', show.get('cgTitle'));
 	},
 
 	model: function(params) {

--- a/app/routes/vods.js
+++ b/app/routes/vods.js
@@ -1,11 +1,10 @@
 import Ember from 'ember';
+import SetPageTitle from 'public/mixins/set-page-title';
 
-export default Ember.Route.extend({
-	headData: Ember.inject.service(),
+export default Ember.Route.extend(SetPageTitle, {
 
 	afterModel() {
-		let headData = this.get('headData');
-		headData.set('title', 'Vods');
+		this.setTitle('Vods');
 	},
 
 	model: function() {

--- a/app/routes/vods.js
+++ b/app/routes/vods.js
@@ -1,6 +1,13 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+	headData: Ember.inject.service(),
+
+	afterModel() {
+		let headData = this.get('headData');
+		headData.set('title', 'Vods');
+	},
+
 	model: function() {
     return this.store.findAll('vod');
   }

--- a/app/routes/watch-now.js
+++ b/app/routes/watch-now.js
@@ -1,11 +1,11 @@
 import Ember from 'ember';
+import SetPageTitle from 'public/mixins/set-page-title';
 
-export default Ember.Route.extend({
+export default Ember.Route.extend(SetPageTitle, {
   headData: Ember.inject.service(),
 
   afterModel(model) {
-    let headData = this.get('headData');
-    headData.set('title', model.liveStream.get('name'));
+    this.setTitle(model.liveStream.get('name'));
   },
 
   model: function(params) {

--- a/app/routes/watch-now.js
+++ b/app/routes/watch-now.js
@@ -1,6 +1,13 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  headData: Ember.inject.service(),
+
+  afterModel(model) {
+    let headData = this.get('headData');
+    headData.set('title', model.liveStream.get('name'));
+  },
+
   model: function(params) {
     return this.store.findRecord('live-stream', params.stream_id).
   						then(function(liveStream){

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -7,6 +7,8 @@
 <link rel="stylesheet" href="{{model.rootURL}}colors-{{model.channelID}}.css">
 <link rel="stylesheet" href="{{model.rootURL}}custom-{{model.channelID}}.css">
 
+<title>{{model.title}}</title>
+
 <meta name="twitter:card" content={{model.socialMedia.card}}>
 <meta name="twitter:title" content="{{model.socialMedia.title}}">
 <meta name="twitter:description" content="{{model.socialMedia.description}}">

--- a/config/environment.js
+++ b/config/environment.js
@@ -3,7 +3,7 @@
 module.exports = function(environment) {
   var ENV = {
     'ember-cli-head': {
-      suppressBrowserRender: true
+      suppressBrowserRender: false
     },
     fastboot: {
       hostWhitelist: [/.+/]

--- a/config/environment.js
+++ b/config/environment.js
@@ -3,7 +3,7 @@
 module.exports = function(environment) {
   var ENV = {
     'ember-cli-head': {
-      suppressBrowserRender: false
+      suppressBrowserRender: true
     },
     fastboot: {
       hostWhitelist: [/.+/]


### PR DESCRIPTION
Turn on ember-cli-head outside of fastboot so the head is updated outside
of the initial render.

Use ember-cli-head to set the <title> tag dynamically in head.hbs

The main page title matches the channel's name. Each show's page will use
the show's name as a title. The live stream page shows the live stream
name.

Other pages show static titles: Vods, Search Results, Podcasts.