### PR TITLE
CC-169 fix sharing on social media when no thumbnail

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -55,14 +55,16 @@ export default Ember.Route.extend(ResetScroll,{
 
   setHeadData(channel) {
     let publicSite = channel.get('publicSite');
-    let logo = publicSite.get('squareLogo.content') || publicSite.get('logo.content');
     let data = {
       type: 'website',
       card: 'summary',
       title: publicSite.get('siteName'),
-      description: publicSite.get('aboutPageDescription'),
-      image: logo && encodeURI(logo.get('url')) || null
+      description: publicSite.get('aboutPageDescription')
     };
+    let logo = publicSite.get('squareLogo.content') || publicSite.get('logo.content');
+    if (logo) {
+      data.image = encodeURI(logo.get('url'));
+    }
     let headData = this.get('headData');
     headData.set('socialMedia', data);
 

--- a/app/routes/show.js
+++ b/app/routes/show.js
@@ -3,22 +3,33 @@ import SetPageTitle from 'public/mixins/set-page-title';
 
 export default Ember.Route.extend(SetPageTitle, {
 	setHeadData(show) {
-    let thumbnail = show.get('showThumbnails').findBy('quality', 'Large');
-    if (!thumbnail) {
-      thumbnail = show.get('showThumbnails.firstObject');
-    }
-		let headData = this.get('headData');
-		let data = {
+    let data = {
 			type: 'video.episode',
 			card: 'summary_large_image',
 			title: show.get('cgTitle'),
-			description: show.get('comments') || show.get('cgTitle'),
-			image: (thumbnail ? encodeURI(thumbnail.get('url')) : null)
+			description: show.get('comments') || show.get('cgTitle')
 		};
+		let thumbnailUrl = this.findAThumbnailUrl(show);
+		if (thumbnailUrl) {
+			data.image = thumbnailUrl;
+		}
+		let headData = this.get('headData');
 		headData.set('socialMedia', data);
-		this.setTitle(show.get('cgTitle'));
 
 		this.appendJsonLD(data, show);
+
+		this.setTitle(show.get('cgTitle'));
+	},
+
+	findAThumbnailUrl(show) {
+		let thumbnail = show.get('showThumbnails').findBy('quality', 'Large');
+		if (!thumbnail) {
+			thumbnail = show.get('showThumbnails.firstObject');
+		}
+		if (thumbnail) {
+			return encodeURI(thumbnail.get('url'));
+		}
+		return this.get('headData.socialMedia.image');
 	},
 
 	appendJsonLD(data, show) {


### PR DESCRIPTION
Live shows set in the future don't have thumbnails by default, this was
causing a random thumbnail to be picked by FB/TW. If no thumbnail is found
for the current show, it will now default to the application route's
thumbnail (the channel square/logo)