### PR TITLE
CC-196 hide galleries with no shows

### DIFF
--- a/app/components/shows-gallery/component.js
+++ b/app/components/shows-gallery/component.js
@@ -15,16 +15,20 @@ export default Ember.Component.extend({
 
   showsTask: task(function * (){
     let search = this.get('gallery.savedShowSearch');
-    if(!search){
+    let limit = this.get('gallery.displayLimit') * 3;
+    let showIds = search.get('results').slice(0,limit);
+
+    if(showIds.length === 0){
       return;
     }
-    let limit = this.get('gallery.displayLimit') * 3;
-    let store = this.get('store');
-    let shows = store.query('show',{
-                  ids: this.get('gallery.savedShowSearch.results').slice(0,limit),
-                  include: 'thumbnail,vod,category,project,producer,reel',
-                  page_size: limit
-                });
+
+    let shows = this.get('store')
+      .query('show',{
+        ids: showIds,
+        include: 'thumbnail,vod,category,project,producer,reel',
+        page_size: limit
+      });
+
     yield shows;
     this.set('shows',shows);
   }),
@@ -32,7 +36,6 @@ export default Ember.Component.extend({
   filteredShows: Ember.computed('shows.[]',function(){
     let shows = this.get('shows') || [];
     let limit = this.get('gallery.displayLimit');
-
     return shows.filterBy('showThumbnails.length').splice(0,limit);
   }),
   actions:{

--- a/app/components/shows-gallery/template.hbs
+++ b/app/components/shows-gallery/template.hbs
@@ -1,4 +1,3 @@
-
 <div class="gallery-title-wrapper">
   <div class="row">
     <div class="col-xs-8 col-xs-offset-2">
@@ -29,6 +28,8 @@
     {{else}}
       {{#each filteredShows as |show|}}
         {{show-stub show=show}}
+      {{else}}
+        <h2 class="gallery-no-shows-warning">No Shows Available</h2>
       {{/each}}
     {{/if}}
   </div>

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -218,6 +218,11 @@ body {
   display: inline-block;
   margin-top:35px;
 }
+.gallery-no-shows-warning{
+  text-align:center;
+  flex:1;
+  margin:0 0 .5em 0;
+}
 
 /* This is a hotfix */
 // It's necessary to undo the Bootstrap container gutter because the ember view div gets in the way.

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -17,7 +17,9 @@
 
 {{#if siteGalleries.length}}
   {{#each siteGalleries as |gallery|}}
-    {{ shows-gallery gallery=gallery}}
+    {{#if (gt gallery.savedShowSearch.results.length 0)}}
+      {{ shows-gallery gallery=gallery}}
+    {{/if}}
   {{/each}}
 {{else}}
   {{shows-gallery gallery=(hash displayName="Recent Shows" displayLimit=12) shows=model.defaultShows}}


### PR DESCRIPTION
please note, galleries that only have shows with missing thumbnails will still show up but I added a ‘No Shows Available’ warning. This should be pretty edge case-y.