### PR TITLE
Add Slack notification to appveyor.yml on build complete CC-246

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,3 +30,8 @@ artifacts:
 notifications:
   - provider: Webhook
     url: https://trms-build-kicker.herokuapp.com/appveyor?failed={{failed}}&branch=master&projectName=cablecast
+
+  - provider: Slack
+    auth_token:
+      secure: RCjrjaDtlVlWvthh0FrzeNGqWLRwibK+rrVW4nnhrJjo2g9OxUCt6cq2fjy3Haq2VJUJdFfC452ndFWPUz1zAA==
+    channel: '#builds'


### PR DESCRIPTION
This will publish a notification to #builds in Slack when a build completes.