### PR TITLE
CC-272 - Fix head data in fastboot

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -13,12 +13,9 @@ export default Ember.Route.extend(ResetScroll,{
   },
 
   getCanonicalUrl() {
+    let url = '';
     let fastboot = this.get('fastboot');
-    let headData = this.get('headData');
-    let url = 'foo';
-    headData.set('channelID', this.get('model.channel.id'));
-    headData.set('rootURL', encodeURI(ENV.rootURL));
-
+    
     if (fastboot.get('isFastBoot')) {
       let protocol = fastboot.get('request.protocol');
       let host = fastboot.get('request.host');
@@ -72,6 +69,8 @@ export default Ember.Route.extend(ResetScroll,{
 
     let url = this.getCanonicalUrl();
     headData.set('url', encodeURI(url));
+    headData.set('channelID', channel.get('id'));
+    headData.set('rootURL', encodeURI(ENV.rootURL));
   },
 
   model: function(params) {


### PR DESCRIPTION
This fixes the head data so that we have propper access to the channel id and root url. This prevents the style tags in fastboot from 404ing on the custom and color css causing a flash of default colors on loading the page.