### PR TITLE
CC-273 - Only request needed shows for gallery page

### DIFF
--- a/app/routes/gallery.js
+++ b/app/routes/gallery.js
@@ -9,12 +9,14 @@ export default Ember.Route.extend(ResetScroll, {
 	},
   model(params){
     let gallery = this.store.findRecord('site-gallery',params.id);
-    let shows = gallery.then((gallery)=>{
-    return this.store.query('show',{
-                              offset: params.page - 1,
-                              ids: gallery.get('savedShowSearch.results'),
-                              include: 'thumbnail,vod,category,project,producer,reel',
-                            });
+    let shows = gallery.then((gallery) => {
+      let pageSize = 50;
+      let ids = gallery.get('savedShowSearch.results').slice(params.page - 1 * pageSize, pageSize);
+      return this.store.query('show',{
+                                offset: params.page - 1,
+                                ids: ids,
+                                include: 'thumbnail,vod,category,project,producer,reel',
+                              });
     });
 
     return Ember.RSVP.hash({


### PR DESCRIPTION
This fixes an issue where large search results would break the gallery page because we would generate urls that had all the show ids of the reults which would cause a URLLength error. We now only request the 50 ids we are trying to display.