### PR TITLE
lock the ember data version to 2.12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-concurrency": "0.7.19",
-    "ember-data": "^2.11.0",
+    "ember-data": "~2.12",
     "ember-export-application-global": "^1.0.5",
     "ember-font-awesome": "3.0.4",
     "ember-load-initializers": "^0.6.3",


### PR DESCRIPTION
Allowing 2.x means it'll currently install 2.14, which is a breaking change