### PR TITLE
CC-547 - Explicitly install express from npm

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
   - bower install
 build_script:
   - node node_modules\ember-cli\bin\ember build --environment=production
-  - cd dist && npm install fastboot-express-middleware
+  - cd dist && npm install express && npm install fastboot-express-middleware
 version: 1.0.{build}
 #cache node_modules and bower_componets between builds to speed up tests
 cache:


### PR DESCRIPTION
I'm not sure how this broke unless it was an upstream change in NPM that changed the way devDependencies are installed when installing a package. Ether way explicitly installing it with the express-fastboot-middleware will make the package present when we package it for redist.