### PR TITLE
CC-1235 Remove Placeholder Image In Public Site

### DIFF
--- a/app/components/show-stub/template.hbs
+++ b/app/components/show-stub/template.hbs
@@ -3,9 +3,7 @@
     {{show-thumbnail show=show quality='Large' class="img-responsive"}}
   {{/link-to}}
 {{else}}
-	<div class="thumbnail-responsive">
-    <img src="{{rootURL}}/images/placeholder.jpg" alt="" class="img-responsive">
-  </div>
+	<div class="thumbnail-responsive"></div>
 {{/if}}
 <h3 class="show-stub-title-header u-break-text">
 	{{link-to show.cgTitle 'show' show.id class="show-stub-title-link"}}


### PR DESCRIPTION
-Remove 'placeholder' graphic for shows without thumbnails.

Don't know if this is the best way to do this, but it does remove the image completely instead of displaying the generic 'placeholder' graphic.